### PR TITLE
add /trunk/html and variations of .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,7 @@ trunk/TAGS
 trunk/webui/build
 trunk/webui/deploy
 trunk/documentation/html
+trunk/html/
 .dir-locals.el
+**/.DS_Store
+**/._.DS_Store


### PR DESCRIPTION
First pull request. You may not want it, but wanted to get used to doing this. I had to add variations of `.DS_Store` to `.gitignore` because I work in OSX and it loves to fill directories with those files. Also, when I created the documentation using Doxygen, it made a directory called `html` in `/trunk`, not in `/trunk/documentation`. Could be I did something wrong there, but it did build the documentation correctly.