### PR TITLE
Low latency

### DIFF
--- a/trunk/src/gx_head/engine/gx_engine.cpp
+++ b/trunk/src/gx_head/engine/gx_engine.cpp
@@ -304,6 +304,9 @@ GxEngine::GxEngine(const string& plugin_dir, ParameterGroups& groups, const gx_s
     if (!options.get_convolver_watchdog()) {
 	ov_disabled |= ov_Convolver;
     }
+    if (!options.get_watchdog_warning()) {
+		warn_disabled=true;
+	}
     if (!options.get_xrun_watchdog()) {
 	ov_disabled |= ov_XRun;
     }

--- a/trunk/src/gx_head/engine/gx_engine_audio.cpp
+++ b/trunk/src/gx_head/engine/gx_engine_audio.cpp
@@ -750,7 +750,7 @@ void ModuleSequencer::check_overload() {
 	gx_print_error(
 	    "watchdog",
 	    boost::format(_("Overload (%s)")) % gx_system::atomic_get(overload_reason));
-    } else {
+    } else if (!warn_disabled) {
 	gx_print_error(
 	    "watchdog",
 	    boost::format(_("Overload ignored (%s)")) % gx_system::atomic_get(overload_reason));

--- a/trunk/src/gx_head/engine/gx_system.cpp
+++ b/trunk/src/gx_head/engine/gx_system.cpp
@@ -687,7 +687,8 @@ CmdlineOptions::CmdlineOptions()
     opt_watchdog_convolver.set_long_name("no-convolver-overload");
     opt_watchdog_convolver.set_description(
 	"disable overload on convolver missed deadline");
-	Glib::OptionEntry opt_watchdog_warning;
+    opt_watchdog_convolver.set_flags(Glib::OptionEntry::FLAG_REVERSE);
+    Glib::OptionEntry opt_watchdog_warning;
     opt_watchdog_warning.set_short_name('W');
     opt_watchdog_warning.set_long_name("no-watchdog-warning");
     opt_watchdog_warning.set_description(

--- a/trunk/src/gx_head/engine/gx_system.cpp
+++ b/trunk/src/gx_head/engine/gx_system.cpp
@@ -486,6 +486,7 @@ CmdlineOptions::CmdlineOptions()
       sporadic_overload(0),
       idle_thread_timeout(0),
       convolver_watchdog(true),
+      watchdog_warning(true),
       xrun_watchdog(false),
       lterminal(false),
       a_save(false),
@@ -686,7 +687,12 @@ CmdlineOptions::CmdlineOptions()
     opt_watchdog_convolver.set_long_name("no-convolver-overload");
     opt_watchdog_convolver.set_description(
 	"disable overload on convolver missed deadline");
-    opt_watchdog_convolver.set_flags(Glib::OptionEntry::FLAG_REVERSE);
+	Glib::OptionEntry opt_watchdog_warning;
+    opt_watchdog_warning.set_short_name('W');
+    opt_watchdog_warning.set_long_name("no-watchdog-warning");
+    opt_watchdog_warning.set_description(
+	"do not pop-up warning for bypassed overload condition");
+    opt_watchdog_warning.set_flags(Glib::OptionEntry::FLAG_REVERSE);
     Glib::OptionEntry opt_watchdog_xrun;
     opt_watchdog_xrun.set_short_name('X');
     opt_watchdog_xrun.set_long_name("xrun-overload");
@@ -700,6 +706,7 @@ CmdlineOptions::CmdlineOptions()
     opt_sporadic_overload.set_arg_description("SECONDS");
     optgroup_overload.add_entry(opt_watchdog_idle, idle_thread_timeout);
     optgroup_overload.add_entry(opt_watchdog_convolver, convolver_watchdog);
+    optgroup_overload.add_entry(opt_watchdog_warning, watchdog_warning);
     optgroup_overload.add_entry(opt_watchdog_xrun, xrun_watchdog);
     optgroup_overload.add_entry(opt_sporadic_overload, sporadic_overload);
 

--- a/trunk/src/headers/gx_modulesequencer.h
+++ b/trunk/src/headers/gx_modulesequencer.h
@@ -302,6 +302,7 @@ protected:
     Glib::Dispatcher    overload_detected;
     const char         *overload_reason;   // name of unit which detected overload
     int                 ov_disabled;	   // bitmask of OverloadType
+    bool                warn_disabled=false;     // No warning pop-up when overload is diasabled
     static int         sporadic_interval; // seconds; overload if at least 2 events in the timespan
 protected:
     void check_overload();

--- a/trunk/src/headers/gx_system.h
+++ b/trunk/src/headers/gx_system.h
@@ -428,6 +428,7 @@ private:
     int sporadic_overload;
     int idle_thread_timeout;
     bool convolver_watchdog;
+    bool watchdog_warning;
     bool xrun_watchdog;
     bool lterminal;
     bool a_save;
@@ -535,6 +536,7 @@ public:
     int get_sporadic_overload() const { return sporadic_overload; }
     bool get_xrun_watchdog() const { return xrun_watchdog; }
     bool get_convolver_watchdog() const { return convolver_watchdog; }
+    bool get_watchdog_warning() const { return watchdog_warning; }
 };
 
 inline BasicOptions& get_options() {


### PR DESCRIPTION
fixes #56  

Here's the new command line option `-W --no-watchdog-warning`. Tested on my RPi, and it works. Only tested the effect on the convolver watchdog as I cannot get any of the other bypassed watchdogs to ever throw a warning. So: 
No overload options - engine bypass due to convolver and notice pop-up appears.
 `-C` option - no engine bypass, warning of bypassed watchdog appears. 
`-C` and `-W` options - no pop-up, just some xruns.
`-W` without `-C` - engine bypass due to convolver and notice pop-up appears

I had this in a new branch called `low_latency`. I am planning on adding some other commits to that branch, so you may want to add a similar one to your repo if you think this is an acceptable pull request.