### PR TITLE
Issue #98 - Install metainfo in prefix (and validate)

### DIFF
--- a/trunk/org.guitarix.guitarix.metainfo.xml
+++ b/trunk/org.guitarix.guitarix.metainfo.xml
@@ -33,4 +33,8 @@
     </screenshot>
   </screenshots>
   <url type="homepage">https://guitarix.org</url>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="0.43" date="2021-12-06" />
+  </releases>
 </component>

--- a/trunk/wscript
+++ b/trunk/wscript
@@ -370,6 +370,8 @@ def configure(conf):
                          os.path.normpath(os.path.join(conf.env['SHAREDIR'], 'guitarix','icons')))
     conf.define_with_env('GX_PIXMAPS_DIR',
                          os.path.normpath(os.path.join(conf.env['SHAREDIR'], 'pixmaps')))
+    conf.define_with_env('GX_METAINFO_DIR',
+                         os.path.normpath(os.path.join(conf.env['SHAREDIR'], 'metainfo')))
 
     conf.define('GX_VERSION', VERSION)
 
@@ -616,7 +618,7 @@ def build(bld):
         bld.install_files(bld.env['GX_SOUND_DIR'], './IR/greathall.wav', chmod=0o664)
         bld.install_files(bld.env['GX_SOUND_BPB_DIR'], bld.path.ant_glob('IR/BestPlugins_Bands/*'), chmod=0o664)
         bld.install_files(bld.env['GX_SOUND_BPA_DIR'], bld.path.ant_glob('IR/BestPlugins_Amps/*'), chmod=0o664)
-        bld.install_files('/usr/share/metainfo/', 'org.guitarix.guitarix.metainfo.xml', chmod=0o664)
+        bld.install_files(bld.env['GX_METAINFO_DIR'], 'org.guitarix.guitarix.metainfo.xml', chmod=0o664)
 
         if not bld.env['DISABLE_NLS']:
             if bld.env['HAVE_LIBLO']:


### PR DESCRIPTION
appdata didn't validate because it needs `content_rating` and `releases`

Closes #98 