### PR TITLE
Fix wrong max value for Tube Model in gx_amp LV2 plugins.

### DIFF
--- a/trunk/src/LV2/gx_amp.lv2/gx_amp.ttl
+++ b/trunk/src/LV2/gx_amp.lv2/gx_amp.ttl
@@ -169,7 +169,7 @@ https://sourceforge.net/apps/mediawiki/guitarix/index.php?title=Cabinet_Impulse_
         lv2:name "Model" ;
         lv2:default 0 ;
         lv2:minimum 0 ;
-        lv2:maximum 17 ;
+        lv2:maximum 18 ;
         lv2:portProperty lv2:integer;
         lv2:portProperty lv2:enumeration ;
         lv2:scalePoint [rdfs:label "12ax7"; rdf:value 0];

--- a/trunk/src/LV2/gx_amp_stereo.lv2/gx_amp_stereo.ttl
+++ b/trunk/src/LV2/gx_amp_stereo.lv2/gx_amp_stereo.ttl
@@ -168,7 +168,7 @@ https://sourceforge.net/apps/mediawiki/guitarix/index.php?title=Cabinet_Impulse_
         lv2:name "Model" ;
         lv2:default 0 ;
         lv2:minimum 0 ;
-        lv2:maximum 17 ;
+        lv2:maximum 18 ;
         lv2:portProperty lv2:integer;
         lv2:portProperty lv2:enumeration ;
         lv2:scalePoint [rdfs:label "12ax7"; rdf:value 0];


### PR DESCRIPTION
Hosts that obey the maximum are unable to use the bypass model.

Signed-off-by: Kristian Amlie <kristian@amlie.name>