### PR TITLE
Support building LV2 plugins for MSWin 

### DIFF
--- a/trunk/README.mswin
+++ b/trunk/README.mswin
@@ -1,0 +1,32 @@
+The guitarix LV2 plugins can be compiled as DSP-only plugins for MSWindows
+(i.e. only the effect part without a nice GUI)
+
+To compile the guitarix LV2 plugins on MS-Windows:
+
+- Download and install MSYS2 from https://www.msys2.org/
+- Start a MinGW64 shell from the install location (e.g. "C:\MSYS64\MinGW64.exe")
+- Inside the shell, install the required packages using pacman:
+  # pacman -Syu
+  # pacman -S unzip pkg-config mingw-w64-x86_64-pkgconf mingw64/mingw-w64-x86_64-libsndfile mingw64/mingw-w64-x86_64-fftw mingw64/mingw-w64-x86_64-libsigc++ mingw64/mingw-w64-x86_64-eigen3 mingw64/mingw-w64-x86_64-libffi libffi-devel
+- Download the guitarix sources, change into its "trunk" directory (where the "waf" file resides)
+  # wget https://github.com/brummer10/guitarix/archive/refs/heads/master.zip
+  # unzip master.zip
+  # cd guitarix-master/trunk
+- Configure and build the plugins:
+  # ./waf configure  		\
+      --check-cxx-compiler=g++	\
+      --no-standalone		\
+      --no-lv2-gui		\
+      --no-faust		\
+      --includeresampler	\
+      --includeconvolver	\
+      --no-avahi		\
+      --no-bluez		\
+      --no-nsm			\
+      --no-desktop-update	\
+      --static-lib		\
+      --ldflags="-shared -static -Wl,-Bstatic -lstdc++ -lpthread -lfftw3f" \
+      --cxxflags="-Wall -DGSEAL_ENABLE -fpermissive -D_USE_MATH_DEFINES" \
+      && ./waf build && ./waf install --destdir=_bin
+- The compiled plugins should show up in the "trunk/_bin/" folder
+- Untested: To compile 32bit versions, start the MinGW32 shell and install the 32bit libraries (in the pacman clause, replace all "mingw64" by "mingw32" and all "x86_64" by "i686")

--- a/trunk/src/LV2/wscript
+++ b/trunk/src/LV2/wscript
@@ -104,6 +104,8 @@ def configure(conf):
     if not conf.env.NOSSE:
         conf.env.SSE2 = append_sse_flags()
 
+    if conf.env['OS'] == 'win32':
+        subdirs.remove('gx_livelooper.lv2')
     for x in subdirs:
         conf.recurse(x);
     conf.recurse('xputty/resources')
@@ -139,6 +141,8 @@ def build(bld):
                     (', <modgui.ttl>', ' '),
                     (', <modguis.ttl>', ' '),
                     ]
+    if bld.env['OS'] == 'win32':
+        subdirs.remove('gx_livelooper.lv2')
     for x in subdirs:
         bld(rule     = g_module.sub_file,
             source   = '%s/manifest.ttl.in' % x,

--- a/trunk/src/zita-convolver/zita-convolver.cc
+++ b/trunk/src/zita-convolver/zita-convolver.cc
@@ -24,6 +24,12 @@
 #include <stdio.h>
 #include "zita-convolver.h"
 
+#ifdef _WIN32
+#define posix_memalign_free _aligned_free
+#define posix_memalign(p, a, s) (((*(p)) = _aligned_malloc((s), (a))), *(p) ?0 :errno)
+#else
+#define posix_memalign_free free
+#endif
 
 
 int zita_convolver_major_version (void)
@@ -657,7 +663,7 @@ void Convlevel::cleanup (void)
     X = _inp_list;
     while (X)
     {
-        for (i = 0; i < _npar; i++) free (X->_ffta [i]);
+        for (i = 0; i < _npar; i++) posix_memalign_free (X->_ffta [i]);
 	delete[] X->_ffta;
 	X1 = X->_next;
 	delete X;
@@ -675,7 +681,7 @@ void Convlevel::cleanup (void)
 	    {
 	        for (i = 0; i < _npar; i++) 
 		{
-                    free (M->_fftb [i]);
+                    posix_memalign_free (M->_fftb [i]);
 		}
 	        delete[] M->_fftb;
 	    }
@@ -683,7 +689,7 @@ void Convlevel::cleanup (void)
 	    delete M;
 	    M = M1;
 	}
-	for (i = 0; i < 3; i++) free (Y->_buff [i]);
+	for (i = 0; i < 3; i++) posix_memalign_free (Y->_buff [i]);
 	Y1 = Y->_next;
 	delete Y;
 	Y = Y1;
@@ -692,9 +698,9 @@ void Convlevel::cleanup (void)
 
     fftwf_destroy_plan (_plan_r2c);
     fftwf_destroy_plan (_plan_c2r);
-    free (_time_data);
-    free (_prep_data);
-    free (_freq_data);
+    posix_memalign_free (_time_data);
+    posix_memalign_free (_prep_data);
+    posix_memalign_free (_freq_data);
     _plan_r2c = 0;
     _plan_c2r = 0;
     _time_data = 0;

--- a/trunk/wscript
+++ b/trunk/wscript
@@ -315,6 +315,9 @@ def configure(conf):
     conf.check_cfg(package='sndfile', args=['--cflags','--libs','sndfile >= 1.0.17'], uselib_store='SNDFILE', mandatory=1)
     conf.check(header_name='fftw3.h', mandatory=1)
     conf.check_cfg(package='fftw3f', args=['--cflags','--libs','fftw3f >= 3.3.8'], uselib_store='FFTW3', mandatory=1)
+    # avoid dynamic linking for MSWin plugins
+    if conf.env['OS'] == 'win32':
+        conf.env['LIB_FFTW3'] = ''
 
     if opt.standalone or opt.new_ladspa:
         try:


### PR DESCRIPTION
API-wise, there is just a single change required to the zita-convolver to compile and work (_aligned_malloc()), see 0e746cc.
The plugins are built as statically linked dynamic libraries to avoid install problems. Commit 1d351a1 prevents fftw3 from being dynamically linked by waf's automagic and the livelooper is disabled because of its additional dependency on libsndfile.
The required steps and flags for "waf configure" are described in the README.mswin.