### PR TITLE
gx_engine: Fix crash if pitchtracker thread creation errored

### DIFF
--- a/trunk/src/gx_head/engine/gx_pitch_tracker.cpp
+++ b/trunk/src/gx_head/engine/gx_pitch_tracker.cpp
@@ -175,6 +175,7 @@ void PitchTracker::start_thread(int priority, int policy) {
 		"PitchTracker",
 		_("error creating realtime thread - tuner not started"));
 	}
+        m_pthr = 0;
     }
     pthread_attr_destroy(&attr);
 }


### PR DESCRIPTION
- pthread_create state that in case of error, the pthread_t is undefined