### PR TITLE
Do not depend on <cstdint> via transitive inclusion

### DIFF
--- a/trunk/src/LV2/DSP/gx_common.h
+++ b/trunk/src/LV2/DSP/gx_common.h
@@ -22,7 +22,7 @@
 #ifndef SRC_HEADERS_GX_COMMON_H_
 #define SRC_HEADERS_GX_COMMON_H_
 
-
+#include <cstdint>
 #include <cstdlib>
 #include <cmath>
 #include <iostream>


### PR DESCRIPTION
Guitarix fails to compile with the upcoming version of GCC (GCC13) due to a change that removes the transitive inclusion of <cstdint> from other standard headers.

See also -
  https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/HLHKK7P5RB3BLQ5CV4STJGUYBFPC2VTB/