### PR TITLE
Fix various user-facing and non-user-facing typos

### DIFF
--- a/trunk/libgxw/gxw/GxKnob.cpp
+++ b/trunk/libgxw/gxw/GxKnob.cpp
@@ -90,7 +90,7 @@ static void gx_knob_class_init(GxKnobClass *klass)
 		widget_class,
 		g_param_spec_int("y-center",
 		                    P_("Y-Center"),
-		                    P_("Verical position of the center, -1 for auto."),
+		                    P_("Vertical position of the center, -1 for auto."),
 		                    -1, 250, -1,
 		                    GParamFlags(G_PARAM_READABLE|G_PARAM_STATIC_STRINGS)));
     gtk_widget_class_install_style_property(

--- a/trunk/libgxwmm/gxwmm/tools/h2def.py
+++ b/trunk/libgxwmm/gxwmm/tools/h2def.py
@@ -58,7 +58,7 @@
 #   /usr/tmp/pygtk/gtk/gdk-base.defs. Two output files are created:
 #   /tmp/gdk-2.10-types.defs and /tmp/gdk-2.10.defs.
 #
-# python h2def.py -n WebKit /usr/incude/webkit-1.0/webkit/*.h \
+# python h2def.py -n WebKit /usr/include/webkit-1.0/webkit/*.h \
 #            >/tmp/webkit.defs
 #
 # - Outputs all the defs for webkit module, setting the module name to WebKit
@@ -80,7 +80,7 @@ _upperstr_pat2 = re.compile(r'([A-Z][A-Z])([A-Z][0-9a-z])')
 _upperstr_pat3 = re.compile(r'^([A-Z])([A-Z])')
 
 def to_upper_str(name):
-    """Converts a typename to the equivalent upercase and underscores
+    """Converts a typename to the equivalent uppercase and underscores
     name.  This is used to form the type conversion macros and enum/flag
     name variables"""
     name = _upperstr_pat1.sub(r'\1_\2', name)
@@ -565,7 +565,7 @@ class DefsWriter:
         self.fp.write('(define-function ' + fname + '\n')
         self.fp.write('  (c-name "' + name + '")\n')
 
-        # Hmmm... Let's asume that a constructor function name
+        # Hmmm... Let's assume that a constructor function name
         # ends with '_new' and it returns a pointer.
         m = func_new_pat.match(name)
         if pointer_pat.match(ret) and m:

--- a/trunk/rcstyles/gx_head_Guitarix.scss
+++ b/trunk/rcstyles/gx_head_Guitarix.scss
@@ -285,7 +285,7 @@ $toolpalette-left:   18px; // label left margin (shrinks when the scrollbar appe
 
 #main_vpaned separator {
     margin: {
-	// sum of top + buttom is used in the preset pane, but can't
+	// sum of top + bottom is used in the preset pane, but can't
 	// be queried by the program. If the values don't
 	// these are the standard values;
 	top: 0px;

--- a/trunk/specmatch/pyjackx.c
+++ b/trunk/specmatch/pyjackx.c
@@ -1702,7 +1702,7 @@ static PyTypeObject pyjack_ClientType = {
     /*tp_as_buffer*/        0,
     /*tp_flags*/            Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
     /* tp_doc */            "JACK client object.\n"
-                            "Instatiate a jackx.Client to interact with a jack server.\n"
+                            "Instantiate a jackx.Client to interact with a jack server.\n"
                             ,
     /* tp_traverse */       0,
     /* tp_clear */          0,

--- a/trunk/src/gx_head/engine/gx_logging.cpp
+++ b/trunk/src/gx_head/engine/gx_logging.cpp
@@ -100,7 +100,7 @@ void GxLogger::write_queued() {
     }
     msgmutex.unlock();
 
-    // feed throught the handler(s)
+    // feed through the handler(s)
     for (std::list<logmsg*>::iterator i = l.begin(); i != l.end(); ++i) {
 	if (queue_all_msgs) {
 	    if (!(*i)->plugged) {

--- a/trunk/src/gx_head/gui/gx_child_process.cpp
+++ b/trunk/src/gx_head/gui/gx_child_process.cpp
@@ -181,7 +181,7 @@ void JackCaptureGui::terminated(bool pgm_found) {
     } else {
         gx_gui::gx_message_popup(
             "  "
-            " ERORR [Jack Capture GUI]\n\n "
+            " ERROR [Jack Capture GUI]\n\n "
             " jack_capture_gui2 is not installed! "
             );
     }

--- a/trunk/src/gx_head/gui/gx_main_window.cpp
+++ b/trunk/src/gx_head/gui/gx_main_window.cpp
@@ -2287,7 +2287,7 @@ bool MainWindow::survive_jack_shutdown() {
 	gx_print_warning("Jack Shutdown",
 				    _("jack has bumped us out!!   "));
 	actions.jackserverconnection->set_active(true);
-	// run only one time whem jackd is running
+	// run only one time when jackd is running
 	return false;
     } else if (!jack->is_jack_down()) {
         // refresh some stuff. Note that it can be executed
@@ -2836,7 +2836,7 @@ MainWindow::MainWindow(gx_engine::GxMachineBase& machine_, gx_system::CmdlineOpt
     }
 
     /*
-    ** Jack client connection and subsequent initalizations
+    ** Jack client connection and subsequent initializations
     */
 
     // state must be loaded before starting jack because connect_jack() uses

--- a/trunk/src/gx_head/gui/gx_preset_window.cpp
+++ b/trunk/src/gx_head/gui/gx_preset_window.cpp
@@ -166,7 +166,7 @@ PresetWindow::PresetWindow(Glib::RefPtr<gx_gui::GxBuilder> bld, gx_engine::GxMac
     preset_column_preset->set_cell_data_func(
 	*preset_cellrenderer, sigc::mem_fun(*this, &PresetWindow::text_func));
 
-    // third colum
+    // third column
     banks_combobox->signal_changed().connect(
 	sigc::mem_fun(*this, &PresetWindow::on_preset_combo_changed));
     std::vector<Gtk::TargetEntry> listTargets3;

--- a/trunk/src/headers/engine.h
+++ b/trunk/src/headers/engine.h
@@ -84,7 +84,7 @@
 //
 //#define USE_MIDI_OUT
 
-// use MIDI controll out
+// use MIDI control out
 #define USE_MIDI_CC_OUT
 
 #ifdef LADSPA_SO

--- a/trunk/src/headers/gx_plugin.h
+++ b/trunk/src/headers/gx_plugin.h
@@ -102,7 +102,7 @@ struct UiBuilder {
     void (*create_fload_switch)(const char *sw_type,const char * id,const char * idf);
     void (*create_mid_rackknob)(const char *id, const char *label);
     // adding additional functions:
-    // If possible don't change the order of the current defintion.
+    // If possible don't change the order of the current definition.
     // new functions need to be added at the following places:
     //  StackBoxBuilder: decl, real implementation
     //  UiBuilderImpl: decl, assign to pointer, call real implementation

--- a/trunk/src/zita-convolver/README
+++ b/trunk/src/zita-convolver/README
@@ -5,4 +5,4 @@ Please refer to the version official archive
 http://kokkinizita.linuxaudio.org/linuxaudio/
 
 These files are only included to ease compilation
-and installion of Guitarix. Don't modify.
+and installation of Guitarix. Don't modify.

--- a/trunk/src/zita-resampler-1.1.0/README
+++ b/trunk/src/zita-resampler-1.1.0/README
@@ -5,4 +5,4 @@ Please refer to the version official archive
 http://kokkinizita.linuxaudio.org/linuxaudio/
 
 These files are only included to ease compilation
-and installion of Guitarix. Don't modify.
+and installation of Guitarix. Don't modify.

--- a/trunk/tools/ampsim/DK/buildlv2/gx_sceleton_rs_X11.lv2/dsp/zita-resampler-1.1.0/README
+++ b/trunk/tools/ampsim/DK/buildlv2/gx_sceleton_rs_X11.lv2/dsp/zita-resampler-1.1.0/README
@@ -5,4 +5,4 @@ Please refer to the version official archive
 http://kokkinizita.linuxaudio.org/linuxaudio/
 
 These files are only included to ease compilation
-and installion of Guitarix. Don't modify.
+and installation of Guitarix. Don't modify.

--- a/trunk/tools/ampsim/DK/buildlv2/gx_sceleton_rs_X11_stereo.lv2/dsp/zita-resampler-1.1.0/README
+++ b/trunk/tools/ampsim/DK/buildlv2/gx_sceleton_rs_X11_stereo.lv2/dsp/zita-resampler-1.1.0/README
@@ -5,4 +5,4 @@ Please refer to the version official archive
 http://kokkinizita.linuxaudio.org/linuxaudio/
 
 These files are only included to ease compilation
-and installion of Guitarix. Don't modify.
+and installation of Guitarix. Don't modify.

--- a/trunk/tools/dunwah2.py
+++ b/trunk/tools/dunwah2.py
@@ -158,7 +158,7 @@ def load_octave(fd):
 def invfreqz(w, h):
     # w: frequency points array
     # h: response array (complex values)
-    # returns the fitted polinomial coeffients A and B of order 3
+    # returns the fitted polynomial coefficients A and B of order 3
     # (biquad filter)
     with open("/tmp/out", "w") as fd:
         save_octave("F", w, fd)
@@ -199,7 +199,7 @@ def estimate(rg, filt, para, impulse, fs):
     # returns biquad filter estimates for each parameter value:
     #  0: (aa) vector of biquad theta * fs
     #  1: (Q) vector of biquad quality factors
-    #  2: (maxh) vector of maxium absolute value of frequency response
+    #  2: (maxh) vector of maximum absolute value of frequency response
     #  3: mean value of real roots
     #  4: (Bconst)  B for freq_const
     #  5: (freq_const)  para value at center of range

--- a/trunk/tools/faustmod.pyx
+++ b/trunk/tools/faustmod.pyx
@@ -106,7 +106,7 @@ cdef class dsp(object):
     use parameter names as index to get/set the value
         parameters are initialized with their default value
 
-    use num_inputs / num_outputs to find out about channel cound
+    use num_inputs / num_outputs to find out about channel count
 
     use init to set the sampling rate (don't forget!)
 


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,./trunk/changelog,./trunk/debian/changelog,./trunk/libgxwmm/gxwmm-generated,./trunk/src/faust-generated,./trunk/src/LV2/faust-generated,./trunk/src/zita-* -L alog,ans,bu,caf,childs,coverd,daa,dout,ecounter,eigth,nd,pres,relese,vai`

Note: this is a curated selection of fixes. The remaining were left out in order to increase the possibility of merge (typo fix PRs are not always greeted with open-arms shall we say).