### PR TITLE
Redeye - Fixes in Chump and Big Chump

### DIFF
--- a/trunk/src/LV2/gx_redeye.lv2/gx_redeye.ttl
+++ b/trunk/src/LV2/gx_redeye.lv2/gx_redeye.ttl
@@ -207,6 +207,7 @@ rdfs:comment """
         lv2:index 3 ;
         lv2:symbol "Feedback" ;
         lv2:name "Feedback";
+        lv2:portProperty pprop:notOnGUI;
         lv2:default 0.0 ;
         lv2:minimum 0.0 ;
         lv2:maximum 1.0 ;

--- a/trunk/src/LV2/gx_redeye.lv2/gx_redeye.ttl
+++ b/trunk/src/LV2/gx_redeye.lv2/gx_redeye.ttl
@@ -99,6 +99,8 @@ rdfs:comment """
         lv2:index 3 ;
         lv2:symbol "Feedback" ;
         lv2:name "Feedback";
+        lv2:portProperty lv2:toggled;
+        lv2:portProperty lv2:integer;
         lv2:default 0 ;
         lv2:minimum 0 ;
         lv2:maximum 1.0 ;


### PR DESCRIPTION
* Big Chump - Missing pprop:notOnGUI, Fixes #102
* Chump - Feedback is a toggle/checkbox (gx_chump.cc has three sliders and a checkbox)

While I'm typing away. One other issue is the [unimplemented rdfs:comment.](https://github.com/brummer10/guitarix/blob/master/trunk/src/LV2/gx_redeye.lv2/gx_redeye.ttl#L63-L67) It is only half done for Chump and not the other two. It will create something to push/toggle in the plugin to see the message but the reward is just three dots. That's not very useful. I suggest you comment these out until there actually is a description in there, not only for Chump but for the other effects as well. Rock on!