### PR TITLE
Include cstdint in gxbooster.cpp

### DIFF
--- a/trunk/src/LV2/gxbooster.lv2/gxbooster.cpp
+++ b/trunk/src/LV2/gxbooster.lv2/gxbooster.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <cstdlib>
+#include <cstdint>
 #include <cmath>
 #include <iostream>
 #include <cstring>


### PR DESCRIPTION
When compiling the master branch on Alpine linux I got
```
gxbooster.cpp:50:11: error: 'int32_t' has not been declared
```
and other similar errors.

The compiler suggested including `cstdint` in `trunk/src/LV2/gxbooster.lv2/gxbooster.cpp`, so I did and it fixed the issue.