### PR TITLE
Replaces the compressor in hardlim.dsp with soft clipper.  

### DIFF
--- a/trunk/src/faust-generated/hardlim.cc
+++ b/trunk/src/faust-generated/hardlim.cc
@@ -7,17 +7,15 @@ namespace hardlim {
 class Dsp: public PluginDef {
 private:
 	int fSampleRate;
-	double fConst1;
-	double fConst2;
-	double fConst3;
-	double fRec4[2];
-	double fConst4;
-	double fConst5;
-	double fRec3[2];
+	double fConst0;
 	double fRec0[2];
 	int iRec1[2];
 	double fRec2[2];
 	FAUSTFLOAT fVbargraph0;
+	double fRec3[2];
+	int iRec4[2];
+	double fRec5[2];
+	FAUSTFLOAT fVbargraph1;
 
 	void clear_state_f();
 	void init(unsigned int sample_rate);
@@ -61,11 +59,12 @@ Dsp::~Dsp() {
 
 inline void Dsp::clear_state_f()
 {
-	for (int l0 = 0; l0 < 2; l0 = l0 + 1) fRec4[l0] = 0.0;
-	for (int l1 = 0; l1 < 2; l1 = l1 + 1) fRec3[l1] = 0.0;
-	for (int l2 = 0; l2 < 2; l2 = l2 + 1) fRec0[l2] = 0.0;
-	for (int l3 = 0; l3 < 2; l3 = l3 + 1) iRec1[l3] = 0;
-	for (int l4 = 0; l4 < 2; l4 = l4 + 1) fRec2[l4] = 0.0;
+	for (int l0 = 0; l0 < 2; l0 = l0 + 1) fRec0[l0] = 0.0;
+	for (int l1 = 0; l1 < 2; l1 = l1 + 1) iRec1[l1] = 0;
+	for (int l2 = 0; l2 < 2; l2 = l2 + 1) fRec2[l2] = 0.0;
+	for (int l3 = 0; l3 < 2; l3 = l3 + 1) fRec3[l3] = 0.0;
+	for (int l4 = 0; l4 < 2; l4 = l4 + 1) iRec4[l4] = 0;
+	for (int l5 = 0; l5 < 2; l5 = l5 + 1) fRec5[l5] = 0.0;
 }
 
 void Dsp::clear_state_f_static(PluginDef *p)
@@ -76,12 +75,7 @@ void Dsp::clear_state_f_static(PluginDef *p)
 inline void Dsp::init(unsigned int sample_rate)
 {
 	fSampleRate = sample_rate;
-	double fConst0 = std::min<double>(1.92e+05, std::max<double>(1.0, double(fSampleRate)));
-	fConst1 = 1.0 / fConst0;
-	fConst2 = std::exp(-(2.0 / fConst0));
-	fConst3 = std::exp(-(1.25e+03 / fConst0));
-	fConst4 = std::exp(-(2.5e+03 / fConst0));
-	fConst5 = 0.99 * (1.0 - fConst4);
+	fConst0 = 1.0 / std::min<double>(1.92e+05, std::max<double>(1.0, double(fSampleRate)));
 	clear_state_f();
 }
 
@@ -95,25 +89,32 @@ void always_inline Dsp::compute(int count, FAUSTFLOAT *input0, FAUSTFLOAT *input
 	for (int i0 = 0; i0 < count; i0 = i0 + 1) {
 		int iTemp0 = iRec1[1] < 1024;
 		double fTemp1 = double(input0[i0]);
-		double fTemp2 = double(input1[i0]);
-		double fTemp3 = std::fabs(std::max<double>(std::fabs(fTemp1), std::fabs(fTemp2)));
-		double fTemp4 = ((fTemp3 > fRec4[1]) ? fConst3 : fConst2);
-		fRec4[0] = fTemp3 * (1.0 - fTemp4) + fRec4[1] * fTemp4;
-		fRec3[0] = fConst4 * fRec3[1] - fConst5 * std::max<double>(2e+01 * std::log10(std::max<double>(2.2250738585072014e-308, fRec4[0])), 0.0);
-		double fTemp5 = std::pow(1e+01, 0.05 * fRec3[0]);
-		double fTemp6 = std::max<double>(fConst1, std::fabs(1.0 - fTemp5));
-		fRec0[0] = ((iTemp0) ? std::max<double>(fRec0[1], fTemp6) : fTemp6);
+		double fTemp2 = std::max<double>(fConst0, std::fabs(0.5610092271509817 * std::max<double>(std::fabs(fTemp1) + -0.8912509381337456, 0.0)));
+		fRec0[0] = ((iTemp0) ? std::max<double>(fRec0[1], fTemp2) : fTemp2);
 		iRec1[0] = ((iTemp0) ? iRec1[1] + 1 : 1);
 		fRec2[0] = ((iTemp0) ? fRec2[1] : fRec0[1]);
 		fVbargraph0 = FAUSTFLOAT(fRec2[0]);
-		double fTemp7 = fTemp5;
-		output0[i0] = FAUSTFLOAT(fTemp1 * fTemp7);
-		output1[i0] = FAUSTFLOAT(fTemp2 * fTemp7);
-		fRec4[1] = fRec4[0];
-		fRec3[1] = fRec3[0];
+		double fTemp3 = fTemp1;
+		double fTemp4 = std::fabs(fTemp3);
+		double fTemp5 = std::max<double>(-1.1087490618662543, std::min<double>(1.1087490618662543, fTemp3));
+		output0[i0] = FAUSTFLOAT(((fTemp4 <= 0.8912509381337456) ? fTemp5 : double((fTemp5 > 0.0) - (fTemp5 < 0.0)) * (4.597740811915485 * (1.1087490618662543 - 0.5 * (fTemp4 + 0.8912509381337456)) * (fTemp4 + -0.8912509381337456) + 0.8912509381337456)));
+		int iTemp6 = iRec4[1] < 1024;
+		double fTemp7 = double(input1[i0]);
+		double fTemp8 = std::max<double>(fConst0, std::fabs(0.5610092271509817 * std::max<double>(std::fabs(fTemp7) + -0.8912509381337456, 0.0)));
+		fRec3[0] = ((iTemp6) ? std::max<double>(fRec3[1], fTemp8) : fTemp8);
+		iRec4[0] = ((iTemp6) ? iRec4[1] + 1 : 1);
+		fRec5[0] = ((iTemp6) ? fRec5[1] : fRec3[1]);
+		fVbargraph1 = FAUSTFLOAT(fRec5[0]);
+		double fTemp9 = fTemp7;
+		double fTemp10 = std::fabs(fTemp9);
+		double fTemp11 = std::max<double>(-1.1087490618662543, std::min<double>(1.1087490618662543, fTemp9));
+		output1[i0] = FAUSTFLOAT(((fTemp10 <= 0.8912509381337456) ? fTemp11 : double((fTemp11 > 0.0) - (fTemp11 < 0.0)) * (4.597740811915485 * (1.1087490618662543 - 0.5 * (fTemp10 + 0.8912509381337456)) * (fTemp10 + -0.8912509381337456) + 0.8912509381337456)));
 		fRec0[1] = fRec0[0];
 		iRec1[1] = iRec1[0];
 		fRec2[1] = fRec2[0];
+		fRec3[1] = fRec3[0];
+		iRec4[1] = iRec4[0];
+		fRec5[1] = fRec5[0];
 	}
 }
 
@@ -124,7 +125,8 @@ void __rt_func Dsp::compute_static(int count, FAUSTFLOAT *input0, FAUSTFLOAT *in
 
 int Dsp::register_par(const ParamReg& reg)
 {
-	reg.registerFloatVar("hardlim.v1","","SON",N_("Rack output Limiter"),&fVbargraph0, 0, 0.0, 1.0, 0, 0);
+	reg.registerFloatVar("hardlim.v1","","SON",N_("Rack output limiter left"),&fVbargraph0, 0, 0.0, 1.0, 0, 0);
+	reg.registerFloatVar("hardlim.v2","","SON",N_("Rack output limiter right"),&fVbargraph1, 0, 0.0, 1.0, 0, 0);
 	return 0;
 }
 

--- a/trunk/src/faust/hardlim.dsp
+++ b/trunk/src/faust/hardlim.dsp
@@ -6,28 +6,33 @@ import("stdfaust.lib");
 import("guitarix.lib");
 rd = library("reducemaps.lib");
 
+softclip_stereo_with_meters(th,x,y) = softclip_stereo(th,x,y) with {
+  softclip(th,x) = softsat(preclip(x)) with {
+    // The softsat function will map [-cth,cth] to [-1,1], but outside of that input range
+    // it is not well behaved.  So, hard clip to the valid input range first.
+    preclip(x) = aa.clip(-cth,cth,x);
+    // Defines a transfer function with linearly decaying derivative ouside of [-th,th]
+    softsat(x) = ba.if(ax<=th,x,ma.signum(x)*((cth-(ax+th)/2.0)*(ax-th)/2.0/(1.0-th) + th));
+    cth = 2-th;                
+    ax=abs(x);
+  };
+  softclip_stereo(th) = (vmeter1:softclip(th)),(vmeter2:softclip(th));
 
-compressor_stereo(ratio,thresh,att,rel,x,y) = cgm*x, cgm*y with {
-  cgm = compression_gain_mono(ratio,thresh,att,rel,max(abs(x),abs(y)));
-};
-
-compression_gain_mono(ratio,thresh,att,rel) =
-  an.amp_follower_ar(att,rel) : ba.linear2db  : outminusindb(ratio,thresh) :
-  kneesmooth(att) : ba.db2linear : vmeter1
-with {
-  // kneesmooth(att) installs a "knee" in the dynamic-range compression,
-  // where knee smoothness is set equal to half that of the compression-attack.
-  // A general 'knee' parameter could be used instead of tying it to att/2:
-  kneesmooth(att)  = si.smooth(ba.tau2pole(att/2.0));
-  // compression gain in dB:
-   outminusindb(ratio,thresh,level) = max(level-thresh,0.0) * (1.0/float(ratio)-1.0) ;
-  // Note: "float(ratio)" REQUIRED when ratio is an integer > 1!
-  // compression meter indicate when the limiter kicks in
-  vmeter1(x) = attach(x, envelop(1.0-x) : vbargraph("v1[nomidi][tooltip:Rack output Limiter]", 0.0, 1.0));
+  // ::: Meter :::
+  vmeter1(x) = attach(x, envelop(max(abs(x)-th,0.0)/th/2) :
+                      vbargraph("v1[nomidi][tooltip:Rack output limiter left]", 0.0, 1.0));
+  vmeter2(x) = attach(x, envelop(max(abs(x)-th,0.0)/th/2) :
+                      vbargraph("v2[nomidi][tooltip:Rack output limiter right]", 0.0, 1.0));
   envelop    = abs : max ~ (1.0/ma.SR) : rd.maxn(1024); 
 };
 
 
-lim = compressor_stereo(100,0,0.0008,0.5);
+
+// This is where soft clipping will start
+clip_ceiling = ba.db2linear(-1.0);  // below 0.0dB
+    
+//lim = compressor_stereo(4,-3.0,0.0008,0.5);
+lim = softclip_stereo_with_meters(clip_ceiling);
 
 process = lim;
+

--- a/trunk/src/gx_head/builder/ampbox.glade
+++ b/trunk/src/gx_head/builder/ampbox.glade
@@ -605,16 +605,47 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GxFastMeter" id="gxfastmeter">
+                      <object class="GtkBox">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="halign">center</property>
                         <property name="margin-bottom">25</property>
-                        <property name="orientation">vertical</property>
-                        <property name="hold">10</property>
-                        <property name="dimen">0</property>
-                        <property name="var-id">hardlim.v1</property>
-                        <property name="falloff">True</property>
+                        <property name="orientation">horizontal</property>
+                        <child>
+                          <object class="GxFastMeter" id="gxfastmeterL">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">center</property>
+                            <property name="margin-left">10</property>
+                            <property name="orientation">vertical</property>
+                            <property name="hold">10</property>
+                            <property name="dimen">0</property>
+                            <property name="var-id">hardlim.v1</property>
+                            <property name="falloff">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GxFastMeter" id="gxfastmeterR">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">center</property>
+                            <property name="margin-right">10</property>
+                            <property name="orientation">vertical</property>
+                            <property name="hold">10</property>
+                            <property name="dimen">0</property>
+                            <property name="var-id">hardlim.v2</property>
+                            <property name="falloff">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">True</property>

--- a/trunk/src/gx_head/gui/gx_main_window.cpp
+++ b/trunk/src/gx_head/gui/gx_main_window.cpp
@@ -2950,12 +2950,14 @@ MainWindow::MainWindow(gx_engine::GxMachineBase& machine_, gx_system::CmdlineOpt
     machine.set_update_parameter(this, "maxlevel.left", true);
     machine.set_update_parameter(this, "maxlevel.right", true);
     machine.set_update_parameter(this, "hardlim.v1", true);
+    machine.set_update_parameter(this, "hardlim.v2", true);
  }
 
 MainWindow::~MainWindow() {
     machine.set_update_parameter(this, "maxlevel.left", false);
     machine.set_update_parameter(this, "maxlevel.right", false);
     machine.set_update_parameter(this, "hardlim.v1", false);
+    machine.set_update_parameter(this, "hardlim.v2", false);
 #if false   // set true to generate a new keyboard accel file
     gtk_accel_map_add_filter("<Actions>/Main/ChangeSkin_*");
     gtk_accel_map_add_filter("<Actions>/Main/Enum_tube.select.*");


### PR DESCRIPTION
This version of the limiter leans into the idea that if the output is in limiting, the problem should be fixed earlier in the chain.  It does however provide a fuzzy kind of distortion when in limiting.

This code also changes to limit bargraphs to per stereo channel.