### PR TITLE
fix(xputty.h): Fix build on FreeBSD

### DIFF
--- a/trunk/src/LV2/xputty/header/xputty.h
+++ b/trunk/src/LV2/xputty/header/xputty.h
@@ -34,7 +34,7 @@
 #include <math.h>
 #include <cairo.h>
 #include "xputty-mswin.h" // no ifdef (waf dependency check)
-#ifdef __linux__
+#if defined (__linux__) || (__FreeBSD__)
 #include <cairo-xlib.h>
 #include <X11/Xutil.h>
 #include <X11/keysym.h>


### PR DESCRIPTION
Not only Linux exists and uses xcairo. Could be a `__unix__ && !apple`-like but for now:
Switch to `#if defined (__linux__) || (__FreeBSD__)` to build also on FreeBSD

cc @yurivict