### PR TITLE
jsonparser: fix null handling

### DIFF
--- a/trunk/src/gx_head/engine/gx_json.cpp
+++ b/trunk/src/gx_head/engine/gx_json.cpp
@@ -477,7 +477,7 @@ void JsonParser::read_next() {
             next_tok = value_number;
             break;
         // read denormal value
-		case 'n': case 'a': case 'i': case 'f':
+		case 'a': case 'i': case 'f':
             next_str = readnumber(c);
             next_tok = value_number;
             break;


### PR DESCRIPTION
This is an attempt to fix #186 .

To be fair, I don't fully understand what the parsing of denormals is doing, but it looks to me like it's eating the first letter of "null" value.

In case of parsing online presets from https://musical-artifacts.com/artifacts.json?apps=guitarix that means it fails when it gets to `"file_hash": null`, which appears in a few entries.
I think it tries to parse the value as `ull` and fails.