### PR TITLE
Fix misordered arguments in src/gx_head/engine/gx_internal_ui_plugins.cpp

### DIFF
--- a/trunk/src/gx_head/engine/gx_internal_ui_plugins.cpp
+++ b/trunk/src/gx_head/engine/gx_internal_ui_plugins.cpp
@@ -142,7 +142,7 @@ void TunerAdapter::init(unsigned int samplingFreq, PluginDef *plugin) {
     // zita-convoler uses 5 levels, so subtract 6
     self.engine.get_sched_priority(policy, priority, 6);
     self.lhc.init(samplingFreq);
-    self.pitch_tracker.init(policy, priority, samplingFreq);
+    self.pitch_tracker.init(priority, policy, samplingFreq);
 }
 
 void TunerAdapter::set_and_check(int use, bool on) {


### PR DESCRIPTION
`priority` and `policy` are accidentally swapped here, causing the tuner feature to fail randomly with message:
`error creating realtime thread - tuner not started`

See also: https://github.com/flathub/org.guitarix.Guitarix/issues/18