### PR TITLE
LV2 plugins gx_amp and gx_amp_stereo: Fixed presence knob, added post-trim knob

### DIFF
--- a/trunk/src/LV2/gx_amp.lv2/gx_amp.ttl
+++ b/trunk/src/LV2/gx_amp.lv2/gx_amp.ttl
@@ -319,6 +319,13 @@ https://sourceforge.net/apps/mediawiki/guitarix/index.php?title=Cabinet_Impulse_
         lv2:minimum 0.0 ;
         lv2:maximum 1.0 ;
         lv2:portProperty lv2:toggled;
+    ] , [ a lv2:InputPort, lv2:ControlPort ;
+        lv2:index   19 ;
+        lv2:symbol  "trim" ;
+        lv2:name    "Post trim" ;
+        lv2:default 1.0 ;
+        lv2:minimum 0.0 ;
+        lv2:maximum 2.0
     ] .
 
 

--- a/trunk/src/LV2/gx_amp.lv2/gxamp.cpp
+++ b/trunk/src/LV2/gx_amp.lv2/gxamp.cpp
@@ -196,7 +196,9 @@ private:
   float*                       schedule_ok;
   float                        schedule_ok_;
   std::atomic<bool>            _execute;
-
+  float                        *trim;
+  float                        trim_, old_trim_; // -delt.
+  
   inline bool cab_changed() 
     {return std::abs(cab - clevel_ ) > 0.1;}
   inline bool buffsize_changed() 
@@ -212,8 +214,10 @@ private:
   inline void update_pre() 
     {pre = (alevel_);}
   inline bool val_changed() 
-    {return  std::abs(alevel_ - (*alevel)) > 0.1 || abs(clevel_ - (*clevel)) > 0.1 || std::abs(c_model_ - (*c_model)) > 0.1;}
-
+    { return  std::abs(alevel_ - (*alevel))        > 0.1
+               || std::abs(clevel_ - (*clevel))    > 0.1
+               || std::abs(c_model_ - (*c_model))  > 0.1
+               || std::fabs (old_trim_ - trim_)    > 0.01; } // -delt.
   // LV2 stuff
   LV2_URID_Map*                map;
   LV2_Worker_Schedule*         schedule;
@@ -283,6 +287,9 @@ GxPluginMono::GxPluginMono() :
   c_old_model_(0),
   alevel(NULL),
   alevel_(0),
+  trim (NULL),
+  trim_ (1.0),  // -delt.
+  old_trim_ (1.0),
   pre(0),
   schedule_ok(NULL),
   schedule_ok_(0)
@@ -316,7 +323,7 @@ void GxPluginMono::do_work_mono()
           ampconv.stop_process();
         }
      bufsize = cur_bufsize;
-	 cabconv.cleanup();
+     cabconv.cleanup();
      CabDesc& cab = *getCabEntry(static_cast<uint32_t>(c_model_)).data;
      cabconv.cab_count = cab.ir_count;
      cabconv.cab_sr = cab.ir_sr;
@@ -490,6 +497,9 @@ void GxPluginMono::connect_mono(uint32_t port,void* data)
     case BYPASS: 
       bypass = static_cast<float*>(data); // , 0.0, 0.0, 1.0, 1.0 
       break;
+    case TRIM:  // -delt.
+      trim = static_cast<float*>(data);
+      break;    
     default:
       break;
     }
@@ -499,7 +509,14 @@ void GxPluginMono::connect_mono(uint32_t port,void* data)
 
 void GxPluginMono::run_dsp_mono(uint32_t n_samples)
 {
-  if (n_samples< 1) return;
+  // Latch TRIM from control port every block (before val_changed())  -delt.
+	if (trim) {
+		float v = *trim;
+		if (!std::isfinite(v)) v = 1.0f;
+		trim_ = v;
+	}
+  
+	if (n_samples< 1) return;
   MXCSR.set_();
   cur_bufsize = n_samples;
   if (*(schedule_ok) != schedule_ok_) *(schedule_ok) = schedule_ok_;
@@ -509,7 +526,8 @@ void GxPluginMono::run_dsp_mono(uint32_t n_samples)
   if (output != input)
     memcpy(output, input, n_samples*sizeof(float));
   // check if bypass is pressed
-  if (!bp.pre_check_bypass(bypass, buf, input, n_samples)) {
+  bool byp = bp.pre_check_bypass(bypass, buf, input, n_samples);
+  if (!byp) {
 #ifndef __SSE__
     wn->mono_audio(static_cast<int>(n_samples), input, input, wn);;
 #endif
@@ -554,12 +572,18 @@ void GxPluginMono::run_dsp_mono(uint32_t n_samples)
   }
   bp.post_check_bypass(buf, output, n_samples);
 
+	if (!byp) {
+		for (unsigned int i = 0; i < n_samples; i++)
+			output [i] *= trim_;
+	}
+  
   MXCSR.reset_();
   // work ?
   if (!_execute.load(std::memory_order_acquire) && (val_changed() || buffsize_changed())) 
     {
       clevel_ = (*clevel);
       alevel_ = (*alevel);
+			old_trim_ = trim_;  // -delt.
       c_model_= (*c_model);
       _execute.store(true, std::memory_order_release);
       schedule->schedule_work(schedule->handle, sizeof(bool), &doit);

--- a/trunk/src/LV2/gx_amp.lv2/gxamp.h
+++ b/trunk/src/LV2/gx_amp.lv2/gxamp.h
@@ -57,8 +57,9 @@ typedef enum
   AMP_INPUT,
   BYPASS,
   HIGHGAIN,
-  AMP_OUTPUT1,
-  AMP_INPUT1,
+  /*AMP_OUTPUT1,   unused in mono gxamp
+  AMP_INPUT1,      -delt.*/
+  TRIM
 } PortIndex;
 
 #endif //SRC_HEADERS_GXAMP_H_

--- a/trunk/src/LV2/gx_amp.lv2/gxamp_ui.cpp
+++ b/trunk/src/LV2/gx_amp.lv2/gxamp_ui.cpp
@@ -32,7 +32,7 @@
 -----------------------------------------------------------------------
 ----------------------------------------------------------------------*/
 
-#define CONTROLS 14
+#define CONTROLS 15   // added master trim knob
 
 /*---------------------------------------------------------------------
 -----------------------------------------------------------------------    
@@ -70,34 +70,39 @@ void plugin_create_controller_widgets(X11_UI *ui, const char * plugin_uri) {
     ui->private_ptr = (void*)ps;
     ps->schedule = 2.0;
 
-    // create knob widgets
-    ui->widget[0] = add_my_knob(ui->widget[0], GAIN1,"Mastergain", ui,745, 60, 90, 115);
-    set_adjustment(ui->widget[0]->adj,0.0, 0.0, -20.0, 20.0, 0.1, CL_CONTINUOS);
+    // create knob widgets:
+    // adjusted X coords for 1 extra knob  -delt.
+    ui->widget[0] = add_my_knob(ui->widget[0], GAIN1, "Master", ui, 670, 60, 90, 115);
+    set_adjustment(ui->widget[0]->adj, 0.0, 0.0, -20.0, 20.0, 0.1, CL_CONTINUOS);
 
-    ui->widget[1] = add_my_knob(ui->widget[1], PREGAIN,"Pregain", ui,100, 60, 90, 115);
-    set_adjustment(ui->widget[1]->adj,0.0, 0.0, -20.0, 20.0, 0.1, CL_CONTINUOS);
+    ui->widget[1] = add_my_knob(ui->widget[1], PREGAIN, "Pregain", ui, 90, 60, 90, 115);
+    set_adjustment(ui->widget[1]->adj, 0.0, 0.0, -20.0, 20.0, 0.1, CL_CONTINUOS);
 
-    ui->widget[2] = add_my_knob(ui->widget[2], WET_DRY,"Distortion", ui,202, 67, 75, 100);
-    set_adjustment(ui->widget[2]->adj,1.0, 1.0, 1.0, 100.0, 1.0, CL_CONTINUOS);
+    ui->widget[2] = add_my_knob(ui->widget[2], WET_DRY, "Distortion", ui, 182, 67, 75, 100);
+    set_adjustment(ui->widget[2]->adj, 1.0, 1.0, 1.0, 100.0, 1.0, CL_CONTINUOS);
 
-    ui->widget[3] = add_my_knob(ui->widget[3], DRIVE,"Drive", ui,285, 70, 70, 95);
-    set_adjustment(ui->widget[3]->adj,0.01, 0.01, 0.01, 1.0, 0.01, CL_CONTINUOS);
+    ui->widget[3] = add_my_knob(ui->widget[3], DRIVE, "Drive", ui, 257, 70, 70, 95);
+    set_adjustment(ui->widget[3]->adj, 0.01, 0.01, 0.01, 1.0, 0.01, CL_CONTINUOS);
 
-    ui->widget[4] = add_my_knob(ui->widget[4], TREBLE,"Treble", ui,365, 72, 65, 90);
-    set_adjustment(ui->widget[4]->adj,0.5, 0.5, 0.0, 1.0, 0.01, CL_CONTINUOS);
+    ui->widget[4] = add_my_knob(ui->widget[4], TREBLE, "Treble", ui, 328, 72, 65, 90);
+    set_adjustment(ui->widget[4]->adj, 0.5, 0.5, 0.0, 1.0, 0.01, CL_CONTINUOS);
 
-    ui->widget[5] = add_my_knob(ui->widget[5], MIDDLE,"Mid", ui,435, 72, 65, 90);
-    set_adjustment(ui->widget[5]->adj,0.5, 0.5, 0.0, 1.0, 0.01, CL_CONTINUOS);
+    ui->widget[5] = add_my_knob(ui->widget[5], MIDDLE, "Mid", ui, 392, 72, 65, 90);
+    set_adjustment(ui->widget[5]->adj, 0.5, 0.5, 0.0, 1.0, 0.01, CL_CONTINUOS);
 
-    ui->widget[6] = add_my_knob(ui->widget[6], BASS,"Bass", ui,505, 72, 65, 90);
-    set_adjustment(ui->widget[6]->adj,0.5, 0.5, 0.0, 1.0, 0.01, CL_CONTINUOS);
+    ui->widget[6] = add_my_knob(ui->widget[6], BASS, "Bass", ui, 455, 72, 65, 90);
+    set_adjustment(ui->widget[6]->adj, 0.5, 0.5, 0.0, 1.0, 0.01, CL_CONTINUOS);
 
-    ui->widget[7] = add_my_knob(ui->widget[7], ALevel,"Presence", ui,580, 70, 70, 95);
-    set_adjustment(ui->widget[7]->adj,5.0, 5.0, 0.0, 10.0, 0.1, CL_CONTINUOS);
+    ui->widget[7] = add_my_knob(ui->widget[7], ALevel, "Presence", ui, 522, 70, 70, 95);
+    set_adjustment(ui->widget[7]->adj, 5.0, 5.0, 0.0, 10.0, 0.1, CL_CONTINUOS);
 
-    ui->widget[8] = add_my_knob(ui->widget[8], CLevel,"Cabinet", ui,660, 67, 75, 100);
-    set_adjustment(ui->widget[8]->adj,1.0, 1.0, 1.0, 20.0, 0.1, CL_CONTINUOS);
+    ui->widget[8] = add_my_knob(ui->widget[8], CLevel, "Cabinet", ui, 594, 67, 75, 100);
+    set_adjustment(ui->widget[8]->adj, 1.0, 1.0, 1.0, 20.0, 0.1, CL_CONTINUOS);
 
+    // ...and added our post trim knob -delt.
+    ui->widget[14] = add_my_knob(ui->widget[14], TRIM, "Post trim", ui, 760, 67, 75, 100);
+    set_adjustment(ui->widget[14]->adj, 0.0, 1.0, 0.0, 2.0, 0.01, CL_CONTINUOS);
+    
     ui->widget[12] = add_on_off_button(ui->win, "Power", 40, 80, 40, 80);
     ui->widget[12]->scale.gravity = ASPECT;
     ui->widget[12]->data = BYPASS;

--- a/trunk/src/LV2/gx_amp_stereo.lv2/gx_amp_stereo.ttl
+++ b/trunk/src/LV2/gx_amp_stereo.lv2/gx_amp_stereo.ttl
@@ -60,8 +60,8 @@
 
   guiext:ui <http://guitarix.sourceforge.net/plugins/gx_amp_stereo#gui>;
   
-    lv2:minorVersion 43;
-    lv2:microVersion 0;
+    lv2:minorVersion 47;
+    lv2:microVersion 2;
 
 rdfs:comment """
 Stereo version of gx_amp.
@@ -227,7 +227,7 @@ https://sourceforge.net/apps/mediawiki/guitarix/index.php?title=Cabinet_Impulse_
         lv2:scalePoint [rdfs:label "Fender Style"; rdf:value 23];
         lv2:scalePoint [rdfs:label "Fender Deville Style"; rdf:value 24];
         lv2:scalePoint [rdfs:label "Gibsen Style"; rdf:value 25];
-        lv2:scalePoint [rdfs:label "Off"; rdf:value 26];
+        lv2:scalePoint [rdfs:label "(Off)"; rdf:value 26];
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;
@@ -257,7 +257,7 @@ https://sourceforge.net/apps/mediawiki/guitarix/index.php?title=Cabinet_Impulse_
         lv2:scalePoint [rdfs:label "Vitalize"; rdf:value 15];
         lv2:scalePoint [rdfs:label "Charisma"; rdf:value 16];
         lv2:scalePoint [rdfs:label "1x8"; rdf:value 17];
-        lv2:scalePoint [rdfs:label "Off"; rdf:value 18];
+        lv2:scalePoint [rdfs:label "(Off)"; rdf:value 18];
     ] , [
         a lv2:InputPort ,
             atom:AtomPort ;
@@ -330,6 +330,13 @@ https://sourceforge.net/apps/mediawiki/guitarix/index.php?title=Cabinet_Impulse_
         lv2:minimum 0.0 ;
         lv2:maximum 1.0 ;
         lv2:portProperty lv2:toggled;
+    ] , [ a lv2:InputPort, lv2:ControlPort ;
+        lv2:index   21 ;
+        lv2:symbol  "trim" ;
+        lv2:name    "Post trim" ;
+        lv2:default 1.0 ;
+        lv2:minimum 0.0 ;
+        lv2:maximum 2.0
     ] .
 
 

--- a/trunk/src/LV2/gx_amp_stereo.lv2/gxamp_stereo.h
+++ b/trunk/src/LV2/gx_amp_stereo.lv2/gxamp_stereo.h
@@ -59,6 +59,7 @@ typedef enum
   AMP_INPUT1,
   BYPASS,
   HIGHGAIN,
+	TRIM
 } PortIndex;
 
 #endif //SRC_HEADERS_GXAMP_H_

--- a/trunk/src/LV2/gx_amp_stereo.lv2/gxamp_stereo_ui.cpp
+++ b/trunk/src/LV2/gx_amp_stereo.lv2/gxamp_stereo_ui.cpp
@@ -32,7 +32,7 @@
 -----------------------------------------------------------------------
 ----------------------------------------------------------------------*/
 
-#define CONTROLS 14
+#define CONTROLS 15 // added post trim knob
 
 /*---------------------------------------------------------------------
 -----------------------------------------------------------------------    
@@ -115,35 +115,39 @@ void plugin_create_controller_widgets(X11_UI *ui, const char * plugin_uri) {
     ps->schedule = 2.0;
     set_my_theme(&ui->main);
     widget_get_png(ui->win, LDVAR(guitarix_png));
-
-
+    
     // create knob widgets
-    ui->widget[0] = add_my_knob(ui->widget[0], GAIN1,"Mastergain", ui,745, 60, 90, 115);
+    // adjusted X coord for 1 extra knob:
+    ui->widget[0] = add_my_knob(ui->widget[0], GAIN1,"Master", ui,670, 60, 90, 115);
     set_adjustment(ui->widget[0]->adj,0.0, 0.0, -20.0, 20.0, 0.1, CL_CONTINUOS);
 
-    ui->widget[1] = add_my_knob(ui->widget[1], PREGAIN,"Pregain", ui,100, 60, 90, 115);
+    ui->widget[1] = add_my_knob(ui->widget[1], PREGAIN,"Pregain", ui,90, 60, 90, 115);
     set_adjustment(ui->widget[1]->adj,0.0, 0.0, -20.0, 20.0, 0.1, CL_CONTINUOS);
 
-    ui->widget[2] = add_my_knob(ui->widget[2], WET_DRY,"Distortion", ui,202, 67, 75, 100);
+    ui->widget[2] = add_my_knob(ui->widget[2], WET_DRY,"Distortion", ui,182, 67, 75, 100);
     set_adjustment(ui->widget[2]->adj,1.0, 1.0, 1.0, 100.0, 1.0, CL_CONTINUOS);
 
-    ui->widget[3] = add_my_knob(ui->widget[3], DRIVE,"Drive", ui,285, 70, 70, 95);
+    ui->widget[3] = add_my_knob(ui->widget[3], DRIVE,"Drive", ui,257, 70, 70, 95);
     set_adjustment(ui->widget[3]->adj,0.01, 0.01, 0.01, 1.0, 0.01, CL_CONTINUOS);
 
-    ui->widget[4] = add_my_knob(ui->widget[4], TREBLE,"Treble", ui,365, 72, 65, 90);
+    ui->widget[4] = add_my_knob(ui->widget[4], TREBLE,"Treble", ui,328, 72, 65, 90);
     set_adjustment(ui->widget[4]->adj,0.5, 0.5, 0.0, 1.0, 0.01, CL_CONTINUOS);
 
-    ui->widget[5] = add_my_knob(ui->widget[5], MIDDLE,"Mid", ui,435, 72, 65, 90);
+    ui->widget[5] = add_my_knob(ui->widget[5], MIDDLE,"Mid", ui,392, 72, 65, 90);
     set_adjustment(ui->widget[5]->adj,0.5, 0.5, 0.0, 1.0, 0.01, CL_CONTINUOS);
 
-    ui->widget[6] = add_my_knob(ui->widget[6], BASS,"Bass", ui,505, 72, 65, 90);
+    ui->widget[6] = add_my_knob(ui->widget[6], BASS,"Bass", ui,455, 72, 65, 90);
     set_adjustment(ui->widget[6]->adj,0.5, 0.5, 0.0, 1.0, 0.01, CL_CONTINUOS);
 
-    ui->widget[7] = add_my_knob(ui->widget[7], ALevel,"Presence", ui,580, 70, 70, 95);
+    ui->widget[7] = add_my_knob(ui->widget[7], ALevel,"Presence", ui,522, 70, 70, 95);
     set_adjustment(ui->widget[7]->adj,5.0, 5.0, 0.0, 10.0, 0.1, CL_CONTINUOS);
 
-    ui->widget[8] = add_my_knob(ui->widget[8], CLevel,"Cabinet", ui,660, 67, 75, 100);
-    set_adjustment(ui->widget[8]->adj,1.0, 1.0, 1.0, 20.0, 0.1, CL_CONTINUOS);
+    ui->widget[8] = add_my_knob(ui->widget[8], CLevel,"Cabinet", ui,594, 67, 75, 100);
+    set_adjustment(ui->widget[8]->adj,1.0, 1.0, 1.0, 20.0, 0.1, CL_CONTINUOS);		
+
+    // ...and added our post trim knob -delt.
+    ui->widget[14] = add_my_knob(ui->widget[14], TRIM, "Post trim", ui, 760, 67, 75, 100);
+    set_adjustment(ui->widget[14]->adj, 0.0, 1.0, 0.0, 2.0, 0.01, CL_CONTINUOS);
 
     ui->widget[12] = add_on_off_button(ui->win, "Power", 40, 80, 40, 80);
     ui->widget[12]->scale.gravity = ASPECT;


### PR DESCRIPTION
The presence knob previously had no effect until value reached 0.1, then a sudden dip in loudness and “resonator” onset. The new taper provides a smoother, more predictable buildup with no image shift or loudness potholes. It also allows to dial in a smaller, more subtle amount of presence.