### PR TITLE
wscript: improve boost check

### DIFF
--- a/trunk/wscript
+++ b/trunk/wscript
@@ -186,8 +186,13 @@ def check_boost(conf):
     #include <boost/system/error_code.hpp>
     int main() { boost::system::error_code c; }
     """
-    msg = "Checking for boost-system "
-    conf.check_cxx(msg = msg, fragment=code, lib="boost_system", uselib_store="BOOST_SYSTEM", mandatory=0,includes='/opt/local/include', libpath='/opt/local/lib')
+    msg = "Checking for boost-system"
+    # boost_system is a stub library since boost 1.69 and is completely removed in boost 1.89
+    try:
+        conf.check_cxx(msg = msg, fragment=code, uselib_store="BOOST_SYSTEM", includes='/opt/local/include', libpath='/opt/local/lib')
+    except ConfigurationError:
+        conf.check_cxx(msg = msg, fragment=code, lib="boost_system", uselib_store="BOOST_SYSTEM", includes='/opt/local/include', libpath='/opt/local/lib')
+        #conf.check_cxx(msg = msg, fragment=code, lib="boost_system-mt", uselib_store="BOOST_SYSTEM", includes='/opt/local/include', libpath='/opt/local/lib')
     # some boost (>1.49) versions depend on boost-system so we will check for it first
     # and later link against boost_system were boost headers are included.
     boost_atleast_version = 104200
@@ -202,13 +207,11 @@ def check_boost(conf):
     int main(){ return 0; }
     """ % boost_atleast_version
     msg = "Checking for boost >= %s" % boost_atleast_vermsg
-    conf.check_cxx(msg = msg, fragment=code, lib="boost_system", mandatory=0)
-    #conf.check_cxx(msg = msg, fragment=code, lib="boost_system-mt", mandatory=0,includes='/opt/local/include', libpath='/opt/local/lib')
+    conf.check_cxx(msg = msg, fragment=code, use='BOOST_SYSTEM', mandatory=1)
 
-    msg = "Checking for boost_iostreams >= %s" % boost_atleast_vermsg
-    conf.check_cxx(msg = msg, fragment=code, lib=["boost_iostreams"], uselib_store="BOOST_IOSTREAMS", mandatory=1)
-    #conf.check_cxx(msg = msg, fragment=code, lib=["boost_iostreams"], uselib_store="BOOST_IOSTREAMS", mandatory=1, includes='/opt/local/include', libpath='/opt/local/lib')
- 
+    msg = "Checking for boost_iostreams"
+    conf.check_cxx(msg = msg, fragment=code, lib=["boost_iostreams"], use='BOOST_SYSTEM', uselib_store="BOOST_IOSTREAMS", mandatory=1)
+
     #try:
     #    conf.check_cxx(
     #        msg = msg % "", fragment=code, lib="boost_thread", uselib_store="BOOST_THREAD",
@@ -217,7 +220,7 @@ def check_boost(conf):
     #    conf.check_cxx(
     #        msg = msg % "-mt",fragment=code, lib="boost_thread-mt",
     #        uselib_store="BOOST_THREAD", mandatory=1)
-    
+
     # not needed: with boost 1.42 Guitarix doesn't generate code which
     #             references the boost threading lib
     #msg = "Checking for boost_thread%%s >= %s" % boost_atleast_vermsg


### PR DESCRIPTION
Make neccessary boost checks mandatory again. Reuse BOOST_SYSTEM parameters in all checks instead of explicitly depending on boost_system.