### PR TITLE
Added unit types to delays.

### DIFF
--- a/trunk/src/LV2/gx_digital_delay.lv2/gx_digital_delay.ttl
+++ b/trunk/src/LV2/gx_digital_delay.lv2/gx_digital_delay.ttl
@@ -84,6 +84,7 @@ rdfs:comment """
         lv2:default 120.0 ;
         lv2:minimum 24.0 ;
         lv2:maximum 360.0 ;
+        units:unit units:bpm;
     ]      , [
         a lv2:InputPort ,
             lv2:ControlPort ;
@@ -216,6 +217,7 @@ rdfs:comment """
         lv2:minimum 24.0 ;
         lv2:maximum 360.0 ;
         lv2:designation time:beatsPerMinute;
+        units:unit units:bpm;
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;

--- a/trunk/src/LV2/gx_digital_delay_st.lv2/gx_digital_delay_st.ttl
+++ b/trunk/src/LV2/gx_digital_delay_st.lv2/gx_digital_delay_st.ttl
@@ -96,6 +96,7 @@ rdfs:comment """
         lv2:default 1.2e+02 ;
         lv2:minimum 24.0 ;
         lv2:maximum 3.6e+02 ;
+        units:unit units:bpm;
     ]      , [
         a lv2:InputPort ,
             lv2:ControlPort ;
@@ -228,6 +229,7 @@ rdfs:comment """
         lv2:minimum 24.0 ;
         lv2:maximum 360.0 ;
         lv2:designation time:beatsPerMinute;
+        units:unit units:bpm;
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;

--- a/trunk/src/LV2/gx_duck_delay.lv2/gx_duck_delay.ttl
+++ b/trunk/src/LV2/gx_duck_delay.lv2/gx_duck_delay.ttl
@@ -120,6 +120,7 @@ The switching controlled by envelope follower
         lv2:default 500.0 ;
         lv2:minimum 1.0 ;
         lv2:maximum 2000.0 ;
+        units:unit units:ms;
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;

--- a/trunk/src/LV2/gx_duck_delay_st.lv2/gx_duck_delay_st.ttl
+++ b/trunk/src/LV2/gx_duck_delay_st.lv2/gx_duck_delay_st.ttl
@@ -157,6 +157,7 @@ The switching controlled by envelope follower
         lv2:default 500.0 ;
         lv2:minimum 1.0 ;
         lv2:maximum 2000 ;
+        units:unit units:ms;
     ] , [
         a lv2:InputPort ,
             lv2:ControlPort ;


### PR DESCRIPTION
This PR adds unit types to the delays. 
This enables the use of the "Tap Tempo" feature in [PiPedal](https://github.com/rerdavies/pipedal) (might work on other software as well).