### PR TITLE
Fix invalid JSON from PresetFile::writeJSON_remote for preset flags

### DIFF
--- a/trunk/src/gx_head/engine/gx_json.cpp
+++ b/trunk/src/gx_head/engine/gx_json.cpp
@@ -901,10 +901,13 @@ void PresetFile::readJSON_remote(JsonParser& jp) {
 	    jp.skip_object();
 	} else if (jp.current_value() == "flag_invalid") {
 	    flags |= PRESET_FLAG_INVALID;
+	    jp.skip_object();
 	} else if (jp.current_value() == "flag_readonly") {
 	    flags |= PRESET_FLAG_READONLY;
+	    jp.skip_object();
 	} else if (jp.current_value() == "flag_versiondiff") {
 	    flags |= PRESET_FLAG_VERSIONDIFF;
+	    jp.skip_object();
 	} else if (jp.current_value() == "presets") {
 	    jp.next(JsonParser::begin_array);
 	    while (jp.peek() != JsonParser::end_array) {
@@ -935,12 +938,15 @@ void PresetFile::writeJSON_remote(gx_system::JsonWriter& jw) {
     }
     if (flags & gx_system::PRESET_FLAG_INVALID) {
 	jw.write_key("flag_invalid");
+	jw.write(1);
     }
     if (flags & gx_system::PRESET_FLAG_READONLY) {
 	jw.write_key("flag_readonly");
+	jw.write(1);
     }
     if (flags & gx_system::PRESET_FLAG_VERSIONDIFF) {
 	jw.write_key("flag_versiondiff");
+	jw.write(1);
     }
     jw.write_key("presets");
     jw.begin_array();


### PR DESCRIPTION
Fixes #277.

When a preset has one of the flag bits set (readonly, invalid, or version-diff), `PresetFile::writeJSON_remote()` writes the key for that flag but never writes a value, so the output ends up looking like:

```
{"name": "TowerImp","mutable": 0,"type": "file","flag_readonly": "presets": ["Dist Rythm Engl","Dist Rythm Peavey"]}
```

`"flag_readonly"` is immediately followed by another key instead of a value, which isn't valid JSON — a strict parser chokes with something like "Expecting ',' delimiter". That matches exactly what eriytt reported in #277 from a raw netcat session against the remote JSON-RPC interface. Guitarix's own `readJSON_remote()` happens to survive this malformed output because its tokenizer only checks whether a key is followed by anything at all before moving on, which is presumably why this has gone unnoticed for a while even though it looks like it was introduced back in 8e0116b while fixing an unrelated deserialization issue.

The fix gives each of the three flag keys an actual value (`1`) when writing. That in turn means the reader needs to consume that value token instead of assuming the next thing it sees is another key, so I added a `skip_object()` call to each of the three flag branches in `readJSON_remote()`, mirroring what's already done for the `mutable` key just above it. I checked that skipping just the writer side (value written, reader untouched) breaks the reader immediately with a token-mismatch exception, and that patching both sides together round-trips correctly and produces valid JSON.
