### PR TITLE
Fix HTTP 302s when trying to download presets due to redirects

### DIFF
--- a/trunk/src/gx_head/gui/gx_preset_window.cpp
+++ b/trunk/src/gx_head/gui/gx_preset_window.cpp
@@ -874,6 +874,8 @@ bool PresetWindow::download_file(Glib::ustring from_uri, Glib::ustring to_path) 
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, out);
     curl_easy_setopt(curl, CURLOPT_URL, from_uri.c_str());
     curl_easy_setopt(curl, CURLOPT_USERAGENT, GX_USERAGENT);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);
 
     res = curl_easy_perform(curl);
     if (CURLE_OK == res) {
@@ -892,6 +894,8 @@ bool PresetWindow::download_file(Glib::ustring from_uri, Glib::ustring to_path) 
             } else if (strstr(ct, "application/json") != NULL) {
                 gx_print_info( "download_file", from_uri);
             } else if (strstr(ct, "application/octet-stream") != NULL) {
+                 gx_print_info( "download_preset", from_uri);
+            } else if (strstr(ct, "text/plain") != NULL) {
                  gx_print_info( "download_preset", from_uri);
             } else {
                 gx_print_error("download", Glib::ustring::compose("Fetching %1 returned data in unexpected encoding \"%2\"", from_uri, ct));


### PR DESCRIPTION
Hi guys, while trying to use the app and downloading plugins, I was getting a bunch of 302 and it wasn't working.

This fix solves my problem.

I am not a cpp dev, nor do I understand how any of this is supposed to work, so please take my fix with a grain of salt. I just thought I'd share what worked for me, as it may be useful.