### PR TITLE
Fix crash: literal LADSPA default hints wrongly scaled by sample rate

### DIFF
--- a/trunk/src/gx_head/engine/ladspaback.cpp
+++ b/trunk/src/gx_head/engine/ladspaback.cpp
@@ -273,11 +273,11 @@ void PortDesc::set_default_value(const LADSPA_PortRangeHint& h, ChangeableValues
     } else if (LADSPA_IS_HINT_DEFAULT_0(h.HintDescriptor)) {
         store.set_dflt(0);
     } else if (LADSPA_IS_HINT_DEFAULT_1(h.HintDescriptor)) {
-        store.set_dflt(1);
+        store.set_dflt(has_sr ? 1.0 / SR : 1);
     } else if (LADSPA_IS_HINT_DEFAULT_100(h.HintDescriptor)) {
-        store.set_dflt(100);
+        store.set_dflt(has_sr ? 100.0 / SR : 100);
     } else if (LADSPA_IS_HINT_DEFAULT_440(h.HintDescriptor)) {
-        store.set_dflt(440);
+        store.set_dflt(has_sr ? 440.0 / SR : 440);
     } else if (LADSPA_IS_HINT_DEFAULT_MINIMUM(h.HintDescriptor)) {
         store.set_dflt(get_low());
     } else if (LADSPA_IS_HINT_DEFAULT_MAXIMUM(h.HintDescriptor)) {


### PR DESCRIPTION
## Bug

`PortDesc::set_default_value()` stores the LADSPA `HINT_DEFAULT_1`/`_100`/`_440` default hints as their literal absolute values. `PortDesc::output()` later multiplies any stored default by the sample rate whenever the port also carries the `SAMPLE_RATE` hint — correct for `LowerBound`/`UpperBound` (those are ratios per the LADSPA spec), but wrong for the literal default hints, which are already absolute values regardless of the `SAMPLE_RATE` hint.

This produces grossly out-of-range defaults for any LADSPA plugin combining `SAMPLE_RATE` with `DEFAULT_440` — e.g. `filter.so`'s `hpf`/`lpf` "Cutoff Frequency" port: `440` becomes `440*44100 = 19404000`, well outside its `[0.00441, 22050]` range. That trips the `lv <= sv && sv <= uv` assertion in `ParameterV`'s constructor and crashes guitarix on startup once such a plugin is loaded (e.g. via the LADSPA/LV2 loader):

```
guitarix: ../src/headers/gx_parameter.h:278: gx_engine::ParameterV<float>::ParameterV(...): Assertion `lv <= sv && sv <= uv' failed.
```

## Fix

Pre-divide the literal default by `SR` when `has_sr` is set, so it round-trips back to the correct absolute value once `output()` rescales it — consistent with how `low`/`up` are already handled for `SAMPLE_RATE`-hinted ports.

## Testing

- `./waf configure --includeconvolver --includeresampler && ./waf build` succeeds cleanly on top of current `master`.
- Reproduced the crash locally by loading `filter.so`'s `hpf` plugin through the LADSPA/LV2 loader (persisting a `dflt` of `1.9404e+07` for its Cutoff Frequency port) and confirmed guitarix aborts with the assertion above on startup with the unpatched code.
- Note: this fix prevents the bad default from being *generated* going forward; it does not retroactively repair a config file that was already saved with the corrupted value (that value is read back verbatim on load). Anyone hitting this already will need to fix or delete their saved plugin config (e.g. `~/.config/guitarix/plugins/ladspa<UniqueID>.js`) once, in addition to updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)