### PR TITLE
Fix macOS build errors (source only)

### DIFF
--- a/trunk/src/gx_head/engine/gx_engine_audio.cpp
+++ b/trunk/src/gx_head/engine/gx_engine_audio.cpp
@@ -668,7 +668,7 @@ bool ModuleSequencer::update_module_lists() {
 	commit_module_lists();
 	if (stateflags & SF_OVERLOAD) {
 	    // hack: jackd need some time for new load statistic
-#if defined(_WINDOWS) || defined(__APPLE__)
+#if defined(_WINDOWS)
         clearoverride_conn=signal_timeout().connect(
             sigc::mem_fun(*this, &ModuleSequencer::clear_override));
 #else

--- a/trunk/src/headers/ParallelThread.h
+++ b/trunk/src/headers/ParallelThread.h
@@ -183,7 +183,7 @@ public:
             int maxDuration = 0;
             while (!getState()) {
                 pthread_mutex_lock(&pWaitProc);
-                if (pthread_cond_timedwait(&pProcCond, &pWaitProc, getTimeOut()) == ETIMEDOUT) {
+                if (timedWait() == ETIMEDOUT) {
                     pthread_mutex_unlock(&pWaitProc);
                     maxDuration +=1;
                     //fprintf(stderr, "%s wait for process %i\n", threadName.c_str(), maxDuration);
@@ -217,7 +217,7 @@ public:
             int maxDuration = 0;
             while (pWait.load(std::memory_order_acquire)) {
                 pthread_mutex_lock(&pWaitProc);
-                if (pthread_cond_timedwait(&pProcCond, &pWaitProc, getTimeOut()) == ETIMEDOUT) {
+                if (timedWait() == ETIMEDOUT) {
                     pthread_mutex_unlock(&pWaitProc);
                     maxDuration +=1;
                     //fprintf(stderr, "%s wait for data %i\n", threadName.c_str(), maxDuration);
@@ -273,7 +273,11 @@ private:
     inline void init() noexcept {
         pthread_condattr_t cond_attr;
         pthread_condattr_init(&cond_attr);
+        #ifndef __APPLE__
+        // macOS has no pthread_condattr_setclock();
+        // timedWait() uses pthread_cond_timedwait_relative_np() instead
         pthread_condattr_setclock(&cond_attr, CLOCK_MONOTONIC);
+        #endif
         pthread_cond_init(&pProcCond, &cond_attr);
         pthread_condattr_destroy(&cond_attr);
         pWaitProc = PTHREAD_MUTEX_INITIALIZER;
@@ -345,6 +349,19 @@ private:
         }
         timeOut.tv_nsec += at;
         return &timeOut;
+    }
+
+    // wait on pProcCond with a timeout of timeoutPeriod microseconds;
+    // pWaitProc must be locked by the caller
+    inline int timedWait() noexcept {
+        #ifdef __APPLE__
+        struct timespec rel;
+        rel.tv_sec = timeoutPeriod / 1000000;
+        rel.tv_nsec = (timeoutPeriod % 1000000) * 1000;
+        return pthread_cond_timedwait_relative_np(&pProcCond, &pWaitProc, &rel);
+        #else
+        return pthread_cond_timedwait(&pProcCond, &pWaitProc, getTimeOut());
+        #endif
     }
 
     // simple implement clock_gettime for windows (8)

--- a/trunk/src/headers/gx_compiler.h
+++ b/trunk/src/headers/gx_compiler.h
@@ -3,6 +3,9 @@
 #ifdef GUITARIX_AS_PLUGIN
 #define __rt_func //__attribute__((section("TEXT,rt_text")))
 #define __rt_data //__attribute__((section("DATA,rt_data")))
+#elif defined(__APPLE__)
+#define __rt_func __attribute__((section("__TEXT,__rt.text,regular,pure_instructions")))
+#define __rt_data __attribute__((section("__DATA,__rt.data")))
 #else
 #define __rt_func __attribute__((section("rt_text")))
 #define __rt_data __attribute__((section("rt_data")))

--- a/trunk/waftools/strip.py
+++ b/trunk/waftools/strip.py
@@ -2,7 +2,7 @@ from waflib import Task, Configure
 from waflib.TaskGen import feature, before_method, after_method
 import sys
 class strip(Task.Task):
-    run_str = '${STRIP} ${SRC}'
+    run_str = '${STRIP} ${STRIPFLAGS} ${SRC}'
     color   = 'BLUE'
 
     def runnable_status(self):
@@ -27,3 +27,7 @@ def add_strip_task(self):
 
 def configure(conf):
     conf.find_program('strip')
+    if sys.platform == 'darwin':
+        # Mach-O dynamic libraries must keep their exported symbols;
+        # only local symbols can be stripped
+        conf.env.STRIPFLAGS = ['-x']


### PR DESCRIPTION
## Summary

Minimal source/tooling patch so the standalone app compiles on macOS. Per review feedback, this PR now contains **no CI workflow changes** — source only. All changes are no-ops on Linux.

## Changes

- **`trunk/src/headers/gx_compiler.h`** — use Mach-O section specifiers for `__rt_func` / `__rt_data` on Apple (`#elif defined(__APPLE__)`), mirroring `src/LV2/DSP/gx_compiler.h`.
- **`trunk/src/headers/ParallelThread.h`** — macOS has no `pthread_condattr_setclock()`; add a `timedWait()` helper that uses `pthread_cond_timedwait_relative_np()` on Apple and the existing `pthread_cond_timedwait()` elsewhere (Linux path unchanged).
- **`trunk/src/gx_head/engine/gx_engine_audio.cpp`** — drop `defined(__APPLE__)` from the overload-clear guard so the standalone macOS build uses the same `Glib::signal_timeout()` path as Linux. The `_WINDOWS` / plugin branch is left untouched.
- **`trunk/waftools/strip.py`** — pass `-x` to `strip` on darwin so exported symbols of dynamic libraries are kept (a bare `strip` fails on Mach-O dylibs).

The version in `trunk/wscript` is left unchanged.

## Testing

Verified the Linux build still compiles cleanly (`waf build`), since the changes are Apple/Windows-guarded and no-ops on Linux.