### PR TITLE
Fix preset download failing due to HTTP redirects

### DIFF
--- a/trunk/src/gx_head/gui/gx_preset_window.cpp
+++ b/trunk/src/gx_head/gui/gx_preset_window.cpp
@@ -874,6 +874,8 @@ bool PresetWindow::download_file(Glib::ustring from_uri, Glib::ustring to_path) 
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, out);
     curl_easy_setopt(curl, CURLOPT_URL, from_uri.c_str());
     curl_easy_setopt(curl, CURLOPT_USERAGENT, GX_USERAGENT);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);
 
     res = curl_easy_perform(curl);
     if (CURLE_OK == res) {


### PR DESCRIPTION
## Problem

When users click a preset in the **Online** menu to download it, Guitarix fails with a parse error and the preset is not imported.

The root cause: `musical-artifacts.com` redirects individual `.gx` preset file downloads to a CDN bucket (`bucket.musical-artifacts.com`) via HTTP 302. libcurl does **not** follow redirects by default, so it saves the HTML redirect page (≈462 bytes) to `/tmp/` instead of the actual preset file. When Guitarix then tries to parse that HTML as a Guitarix preset bank, it fails with a parse error.

Example redirect chain:
```
GET https://musical-artifacts.com/artifacts/7253/Jeb_Spaghetti_Western.gx
→ 302 https://bucket.musical-artifacts.com/uploads/stored_file/file/11145/Jeb_Spaghetti_Western.gx
→ 200 (actual .gx file, ~35 KB)
```

Without the fix, libcurl saves:
```html
<html><body>You are being <a href="https://bucket.musical-artifacts.com/...">redirected</a>.</body></html>
```

## Fix

Add `CURLOPT_FOLLOWLOCATION` to `download_file()` so libcurl follows HTTP redirects automatically, with `CURLOPT_MAXREDIRS` as a safety cap.

This is the same fix proposed in #282, rebased cleanly on current master (which has changed significantly since that PR was opened against V0.47.0).

## Testing

Verified on Linux with Guitarix built from master: Online preset menu now successfully downloads and imports presets from musical-artifacts.com.